### PR TITLE
Bm unitals

### DIFF
--- a/doc/_Chapter_Libraries_and_classes_of_abstract_unitals.xml
+++ b/doc/_Chapter_Libraries_and_classes_of_abstract_unitals.xml
@@ -23,9 +23,10 @@ as <C>HermitianAbstractUnital(<A>q</A>)</C>.
 
 <ManSection>
   <Func Arg="q" Name="AllBuekenhoutMetzAbstractUnitalParameters" />
- <Returns>All the pairs of <M>GF(q^2)</M> which are possible parameters of a(n orthogonal) Buekenhout-Metz unital of order <A>q</A>.
+ <Returns>All the pairs over <M>GF(q^2)</M> which are possible parameters of a(n orthogonal) Buekenhout-Metz unital of order <A>q</A>.
 </Returns>
  <Description>
+The argument <A>q</A> must be a prime power (if even, then at least 4).
 If <A>q</A> is an odd prime power and <M>(\alpha, \beta)</M> is 2-tuple of
 <M>GF(q^2)</M>, then this pair is a suitable parameter of an orthogonal
 Buekenhout-Metz unital, if <M>(\beta^q - \beta)^2 + 4 \alpha^{q + 1}</M> is
@@ -36,6 +37,25 @@ Buekenhout-Metz unital, if <M>\beta \not\in GF(q)</M> and <M>\alpha^{q +
 1}(\beta^q + \beta)^2</M> has absolute trace 0.
 In both cases <Math>\alpha = 0</Math> yields the Hermitian classical unital, hence we
 omit the tuples with <M>\alpha = 0</M>.
+ </Description>
+</ManSection>
+
+
+<ManSection>
+  <Func Arg="q, alpha, beta" Name="OrthogonalBuekenhoutMetzAbstractUnital" />
+ <Returns>The unital object, which is the abstract unital of order <A>q</A> isomorphic to the orthogonal Buekenhout-Metz unital with parameters <A>alpha</A> and <A>beta</A> in the classical projective plane.
+</Returns>
+ <Description>
+The argument <A>q</A> must be a prime power (if even, then at least 4), the
+other arguments <A>alpha</A> and <A>beta</A> - elements of <M>GF(q^2)</M> -
+must be a pair from
+<C>AllBuekenhoutMetzAbstractUnitalParameters(</C><A>q</A><C>)</C>.
+The point set <M>U_{\alpha, \beta} = \left\{ ( x, \alpha x^2 + \beta x^{q +
+1} + r, 1) \colon x \in GF(q^2), r \in GF(q) \right\} \cup
+\left\{ (0, 1, 0) \right\}</M> in <M>PG(2,q^2)</M> is a unital (called the
+orthogonal Buekenhout-Metz unital) if the pair of parameters <M>(\alpha,
+\beta)</M> satisfies the conditions explained in the description of
+<C>AllBuekenhoutMetzAbstractUnitalParameters(</C><A>q</A><C>)</C>.
  </Description>
 </ManSection>
 

--- a/doc/_Chapter_Libraries_and_classes_of_abstract_unitals.xml
+++ b/doc/_Chapter_Libraries_and_classes_of_abstract_unitals.xml
@@ -15,8 +15,47 @@
 The Hermitian curve has the following canonical equation: <M>X_0^{q + 1} +
 X_1^{q + 1} + X_2^{q + 1} = 0</M>. The function computes the blocks of the
 unital with the help of <C>PGU(3,<A>q</A>)</C> and calls
-<C>AbstractUnitalByDesignBlocks</C>. The <C>Name</C> of the unital is set as
-<C>HermitianAbstractUnital(<A>q</A>)</C>.
+<C>AbstractUnitalByDesignBlocks</C>. The <C>Name</C> of the unital is set
+as <C>HermitianAbstractUnital(<A>q</A>)</C>.
+ </Description>
+</ManSection>
+
+
+<ManSection>
+  <Func Arg="q" Name="AllBuekenhoutMetzAbstractUnitalParameters" />
+ <Returns>All the pairs of <M>GF(q^2)</M> which are possible parameters of a(n orthogonal) Buekenhout-Metz unital of order <A>q</A>.
+</Returns>
+ <Description>
+If <A>q</A> is an odd prime power and <M>(\alpha, \beta)</M> is 2-tuple of
+<M>GF(q^2)</M>, then this pair is a suitable parameter of an orthogonal
+Buekenhout-Metz unital, if <M>(\beta^q - \beta)^2 + 4 \alpha^{q + 1}</M> is
+a nonsquare in <M>GF(q)</M>.
+If <A>q</A> is an even prime power and <M>(\alpha, \beta)</M> is 2-tuple of
+<M>GF(q^2)</M>, then this pair is a suitable parameter of an orthogonal
+Buekenhout-Metz unital, if <M>\beta \not\in GF(q)</M> and <M>\alpha^{q +
+1}(\beta^q + \beta)^2</M> has absolute trace 0.
+In both cases <Math>\alpha = 0</Math> yields the Hermitian classical unital, hence we
+omit the tuples with <M>\alpha = 0</M>.
+ </Description>
+</ManSection>
+
+
+<ManSection>
+  <Func Arg="q" Name="BuekenhoutTitsAbstractUnital" />
+ <Returns>The unital object, which is the abstract unital of order <A>q</A> isomorphic to the Buekenhout-Tits unital in the classical projective plane.
+</Returns>
+ <Description>
+The argument <A>q</A> must be a power of 2, such that the exponent is an
+odd integer at least 3.
+The point set <M>U_T = \left\{ ( x_0 + x_1 \delta, y_0 + (x_0^{\tau + 2} +
+x_1^\tau + x_0x_1)\delta, 1) \colon x_0, x_1, y_0 \in GF(q)\right\} \cup
+\left\{ (0,1,0) \right\}</M> in <M>PG(2,q^2)</M> is a unital (called the
+Buekenhout-Tits unital) if <M>\delta \in GF(q^2) \setminus GF(4)</M> and
+<M>\delta^q = 1 + \delta</M>. This <M>\delta</M> is just a basis element
+along with 1 in <M>GF(q^2)</M> over <M>GF(q)</M>, hence we can omit it as a
+parameter. The function <M>\tau \colon GF(q) \rightarrow GF(q)</M> assigns
+to the field element <M>x</M> the following: <M>x \mapsto x^{2^\frac{k +
+1}{2}}</M>, where <M>q = 2^k</M>.
  </Description>
 </ManSection>
 

--- a/doc/_Chapter_UnitalSZ_automatic_generated_documentation.xml
+++ b/doc/_Chapter_UnitalSZ_automatic_generated_documentation.xml
@@ -8,15 +8,20 @@
 <Heading>UnitalSZ automatic generated documentation of global functions</Heading>
 
 <ManSection>
-  <Func Arg="q" Name="HermitianAbstractUnital" />
- <Returns>The classical unital object, which is the abstract unital of order <A>q</A> isomorphic to the Hermitian curve in the classical projective plane.
+  <Func Arg="q" Name="AllBuekenhoutMetzAbstractUnitalParameters" />
+ <Returns>All the pairs of <M>GF(q^2)</M> which are possible parameters of a(n orthogonal) Buekenhout-Metz unital of order <A>q</A>.
 </Returns>
  <Description>
-The Hermitian curve has the following canonical equation: <M>X_0^{q + 1} +
-X_1^{q + 1} + X_2^{q + 1} = 0</M>. The function computes the blocks of the
-unital with the help of <C>PGU(3,<A>q</A>)</C> and calls
-<C>AbstractUnitalByDesignBlocks</C>. The <C>Name</C> of the unital is set as
-<C>HermitianAbstractUnital(<A>q</A>)</C>.
+If <A>q</A> is an odd prime power and <M>(\alpha, \beta)</M> is 2-tuple of
+<M>GF(q^2)</M>, then this pair is a suitable parameter of an orthogonal
+Buekenhout-Metz unital, if <M>(\beta^q - \beta)^2 + 4 \alpha^{q + 1}</M> is
+a nonsquare in <M>GF(q)</M>.
+If <A>q</A> is an even prime power and <M>(\alpha, \beta)</M> is 2-tuple of
+<M>GF(q^2)</M>, then this pair is a suitable parameter of an orthogonal
+Buekenhout-Metz unital, if <M>\beta \not\in GF(q)</M> and <M>\alpha^{q +
+1}(\beta^q + \beta)^2</M> has absolute trace 0.
+In both cases <Math>\alpha = 0</Math> yields the Hermitian classical unital, hence we
+we omit the tuples with <M>\alpha = 0</M>.
  </Description>
 </ManSection>
 

--- a/gap/constructions.gd
+++ b/gap/constructions.gd
@@ -4,7 +4,8 @@
 # Declarations
 #
 
-#! @ChapterInfo Libraries and classes of abstract unitals, Classes of abstract unitals
+#! @ChapterInfo Libraries and classes of abstract unitals, Classes of abstract
+#!  unitals
 #! @Arguments q
 #! @Returns
 #!   The classical unital object, which is the abstract unital of order <A>q</A>
@@ -13,6 +14,24 @@
 #!   The Hermitian curve has the following canonical equation: <M>X_0^{q + 1} +
 #!   X_1^{q + 1} + X_2^{q + 1} = 0</M>. The function computes the blocks of the
 #!   unital with the help of <C>PGU(3,<A>q</A>)</C> and calls
-#!   <C>AbstractUnitalByDesignBlocks</C>. The <C>Name</C> of the unital is set as
-#!   <C>HermitianAbstractUnital(<A>q</A>)</C>.
+#!   <C>AbstractUnitalByDesignBlocks</C>. The <C>Name</C> of the unital is set
+#!   as <C>HermitianAbstractUnital(<A>q</A>)</C>.
 DeclareGlobalFunction( "HermitianAbstractUnital" );
+#! @Arguments q
+#! @Returns
+#!  All the pairs of <M>GF(q^2)</M> which are possible parameters of a(n
+#!  orthogonal) Buekenhout-Metz unital of order <A>q</A>.
+#! @Description
+#!  If <A>q</A> is an odd prime power and <M>(\alpha, \beta)</M> is 2-tuple of
+#!  <M>GF(q^2)</M>, then this pair is a suitable parameter of an orthogonal
+#!  Buekenhout-Metz unital, if <M>(\beta^q - \beta)^2 + 4 \alpha^{q + 1}</M> is
+#!  a nonsquare in <M>GF(q)</M>.
+#!
+#!  If <A>q</A> is an even prime power and <M>(\alpha, \beta)</M> is 2-tuple of
+#!  <M>GF(q^2)</M>, then this pair is a suitable parameter of an orthogonal
+#!  Buekenhout-Metz unital, if <M>\beta \not\in GF(q)</M> and <M>\alpha^{q +
+#!  1}(\beta^q + \beta)^2</M> has absolute trace 0.
+#!
+#!  In both cases $\alpha = 0$ yields the Hermitian classical unital, hence we
+#!  we omit the tuples with <M>\alpha = 0</M>.
+DeclareGlobalFunction( "AllBuekenhoutMetzAbstractUnitalParameters" );

--- a/gap/constructions.gd
+++ b/gap/constructions.gd
@@ -4,8 +4,7 @@
 # Declarations
 #
 
-#! @ChapterInfo Libraries and classes of abstract unitals, Classes of abstract
-#!  unitals
+#! @ChapterInfo Libraries and classes of abstract unitals, Classes of abstract unitals
 #! @Arguments q
 #! @Returns
 #!   The classical unital object, which is the abstract unital of order <A>q</A>
@@ -17,6 +16,7 @@
 #!   <C>AbstractUnitalByDesignBlocks</C>. The <C>Name</C> of the unital is set
 #!   as <C>HermitianAbstractUnital(<A>q</A>)</C>.
 DeclareGlobalFunction( "HermitianAbstractUnital" );
+#! @ChapterInfo Libraries and classes of abstract unitals, Classes of abstract unitals
 #! @Arguments q
 #! @Returns
 #!  All the pairs of <M>GF(q^2)</M> which are possible parameters of a(n
@@ -33,5 +33,23 @@ DeclareGlobalFunction( "HermitianAbstractUnital" );
 #!  1}(\beta^q + \beta)^2</M> has absolute trace 0.
 #!
 #!  In both cases $\alpha = 0$ yields the Hermitian classical unital, hence we
-#!  we omit the tuples with <M>\alpha = 0</M>.
+#!  omit the tuples with <M>\alpha = 0</M>.
 DeclareGlobalFunction( "AllBuekenhoutMetzAbstractUnitalParameters" );
+#! @ChapterInfo Libraries and classes of abstract unitals, Classes of abstract unitals
+#! @Arguments q
+#! @Returns
+#!  The unital object, which is the abstract unital of order <A>q</A>
+#!  isomorphic to the Buekenhout-Tits unital in the classical projective plane.
+#! @Description
+#!  The argument <A>q</A> must be a power of 2, such that the exponent is an
+#!  odd integer at least 3.
+#!  The point set <M>U_T = \left\{ ( x_0 + x_1 \delta, y_0 + (x_0^{\tau + 2} +
+#!  x_1^\tau + x_0x_1)\delta, 1) \colon x_0, x_1, y_0 \in GF(q)\right\} \cup
+#!  \left\{ (0,1,0) \right\}</M> in <M>PG(2,q^2)</M> is a unital (called the
+#!  Buekenhout-Tits unital) if <M>\delta \in GF(q^2) \setminus GF(4)</M> and
+#!  <M>\delta^q = 1 + \delta</M>. This <M>\delta</M> is just a basis element
+#!  along with 1 in <M>GF(q^2)</M> over <M>GF(q)</M>, hence we can omit it as a
+#!  parameter. The function <M>\tau \colon GF(q) \rightarrow GF(q)</M> assigns
+#!  to the field element <M>x</M> the following: <M>x \mapsto x^{2^\frac{k +
+#!  1}{2}}</M>, where <M>q = 2^k</M>.
+DeclareGlobalFunction( "BuekenhoutTitsAbstractUnital" );

--- a/gap/constructions.gd
+++ b/gap/constructions.gd
@@ -19,9 +19,11 @@ DeclareGlobalFunction( "HermitianAbstractUnital" );
 #! @ChapterInfo Libraries and classes of abstract unitals, Classes of abstract unitals
 #! @Arguments q
 #! @Returns
-#!  All the pairs of <M>GF(q^2)</M> which are possible parameters of a(n
+#!  All the pairs over <M>GF(q^2)</M> which are possible parameters of a(n
 #!  orthogonal) Buekenhout-Metz unital of order <A>q</A>.
 #! @Description
+#!  The argument <A>q</A> must be a prime power (if even, then at least 4).
+#!
 #!  If <A>q</A> is an odd prime power and <M>(\alpha, \beta)</M> is 2-tuple of
 #!  <M>GF(q^2)</M>, then this pair is a suitable parameter of an orthogonal
 #!  Buekenhout-Metz unital, if <M>(\beta^q - \beta)^2 + 4 \alpha^{q + 1}</M> is
@@ -35,6 +37,25 @@ DeclareGlobalFunction( "HermitianAbstractUnital" );
 #!  In both cases $\alpha = 0$ yields the Hermitian classical unital, hence we
 #!  omit the tuples with <M>\alpha = 0</M>.
 DeclareGlobalFunction( "AllBuekenhoutMetzAbstractUnitalParameters" );
+#! @ChapterInfo Libraries and classes of abstract unitals, Classes of abstract unitals
+#! @Arguments q, alpha, beta
+#! @Returns
+#!  The unital object, which is the abstract unital of order <A>q</A>
+#!  isomorphic to the orthogonal Buekenhout-Metz unital with parameters
+#!  <A>alpha</A> and <A>beta</A> in the classical projective plane.
+#! @Description
+#!  The argument <A>q</A> must be a prime power (if even, then at least 4), the
+#!  other arguments <A>alpha</A> and <A>beta</A> - elements of <M>GF(q^2)</M> -
+#!  must be a pair from
+#!  <C>AllBuekenhoutMetzAbstractUnitalParameters(</C><A>q</A><C>)</C>.
+#!
+#!  The point set <M>U_{\alpha, \beta} = \left\{ ( x, \alpha x^2 + \beta x^{q +
+#!  1} + r, 1) \colon x \in GF(q^2), r \in GF(q) \right\} \cup
+#!  \left\{ (0, 1, 0) \right\}</M> in <M>PG(2,q^2)</M> is a unital (called the
+#!  orthogonal Buekenhout-Metz unital) if the pair of parameters <M>(\alpha,
+#!  \beta)</M> satisfies the conditions explained in the description of
+#!  <C>AllBuekenhoutMetzAbstractUnitalParameters(</C><A>q</A><C>)</C>.
+DeclareGlobalFunction( "OrthogonalBuekenhoutMetzAbstractUnital" );
 #! @ChapterInfo Libraries and classes of abstract unitals, Classes of abstract unitals
 #! @Arguments q
 #! @Returns

--- a/gap/constructions.gi
+++ b/gap/constructions.gi
@@ -44,3 +44,44 @@ function( q )
     fi;
     return parampairs;
 end );
+
+InstallGlobalFunction( BuekenhoutTitsAbstractUnital,
+function(q)
+    local tau, delta, bt_points, xy, v, bmat, a, line, blist, mb, u;
+    if not IsPrimePowerInt( q ) or IsOddInt( q ) then
+        Error( "the parameter must be power of 2 with odd exponent at least 3" );
+    fi;
+    if IsEvenInt( Dimension( GF(q) ) ) then
+        Error( "the parameter must be power of 2 with odd exponent at least 3" );
+    fi;
+    tau := 2^( (Dimension( GF(q) ) + 1) / 2 );
+    delta := First( GF(q^2), d -> d^q=d+1 and d<>d^(q-1) );
+    bt_points := [];
+    for xy in Tuples( GF(q), 3 ) do;
+        v := [ xy[1] + xy[2]*delta,
+               xy[3] + ( xy[1]^( tau + 2 ) + xy[2]^tau + xy[1]*xy[2] )*delta,
+               One(GF(q^2)) ];
+        Add( bt_points, v );
+    od;
+    v := [ Zero(GF(q^2)), One(GF(q^2)), Zero(GF(q^2)) ];
+    Add( bt_points, v );
+    bmat := [];
+    for a in GF(q^2) do;
+        line := [ One(GF(q^2)), Zero(GF(q^2)), a ];
+        blist := List( bt_points, p -> line * p = Zero(GF(q^2)) );
+        if SizeBlist( blist ) = q + 1 then
+            Add( bmat, blist );
+        fi;
+    od;
+    for mb in Tuples( GF(q^2), 2 ) do;
+        line := [ mb[1], One(GF(q^2)), mb[2] ];
+        blist := List( bt_points, p -> line * p = Zero(GF(q^2)) );
+        if SizeBlist( blist ) = q + 1 then
+            Add( bmat, blist );
+        fi;
+    od;
+    u := AbstractUnitalByBlistList( bmat );
+    SetName( u, Concatenation( "BuekenhoutTitsAbstractUnital(", String(q), ")" ) );
+    SetPointNamesOfUnital( u, bt_points );
+    return u;
+end );

--- a/gap/constructions.gi
+++ b/gap/constructions.gi
@@ -45,8 +45,61 @@ function( q )
     return parampairs;
 end );
 
+InstallGlobalFunction( OrthogonalBuekenhoutMetzAbstractUnital,
+function( q, alpha, beta )
+    local y, bm_points, x, r, v, bmat, a, line, blist, mb, u;
+    if not IsPrimePowerInt( q ) then
+        Error( "the first parameter must be a prime power" );
+    fi;
+    if IsOddInt( q ) then
+        y := X( GF(q), "y" );
+        if RootsOfUPol( GF(q),
+                        y^2 - ((beta^q - beta)^2 + 4 * alpha^(q + 1)) )
+           <> [] then
+           Error( "(beta^q - beta)^2 + 4 * alpha^(q + 1) must be a nonsquare over GF(q) for odd q" );
+        fi;
+    fi;
+    if IsEvenInt( q ) then
+        if Trace( GF(q), alpha^(q + 1) / (beta^q + beta)^2 ) <> Zero( GF(2) )
+            then
+           Error( "alpha^(q + 1) / (beta^q + beta)^2 must have absolute trace 0 for even q" );
+        fi;
+        if q < 4 then
+            Error( "if q is even, then it must be at least 4" );
+        fi;
+    fi;
+    bm_points := [];
+    for x in GF(q^2) do;
+        for r in GF(q) do;
+            v := [ x, alpha*x^2 + beta*x^(q + 1) + r, One(GF(q^2)) ];
+            Add( bm_points, v );
+        od;
+    od;
+    v := [ Zero(GF(q^2)), One(GF(q^2)), Zero(GF(q^2)) ];
+    Add( bm_points, v );
+    bmat := [];
+    for a in GF(q^2) do;
+        line := [ One(GF(q^2)), Zero(GF(q^2)), a ];
+        blist := List( bm_points, p -> line * p = Zero(GF(q^2)) );
+        if SizeBlist( blist ) = q + 1 then
+            Add( bmat, blist );
+        fi;
+    od;
+    for mb in Tuples( GF(q^2), 2 ) do;
+        line := [ mb[1], One(GF(q^2)), mb[2] ];
+        blist := List( bm_points, p -> line * p = Zero(GF(q^2)) );
+        if SizeBlist( blist ) = q + 1 then
+            Add( bmat, blist );
+        fi;
+    od;
+    u := AbstractUnitalByBlistList( bmat );
+    SetName( u, Concatenation( "OrthogonalBuekenhoutMetzAbstractUnital(", String(q), ",", String(alpha), ",", String(beta), ")" ) );
+    SetPointNamesOfUnital( u, bm_points );
+    return u;
+end );
+
 InstallGlobalFunction( BuekenhoutTitsAbstractUnital,
-function(q)
+function( q )
     local tau, delta, bt_points, xy, v, bmat, a, line, blist, mb, u;
     if not IsPrimePowerInt( q ) or IsOddInt( q ) then
         Error( "the parameter must be power of 2 with odd exponent at least 3" );

--- a/gap/constructions.gi
+++ b/gap/constructions.gi
@@ -19,3 +19,28 @@ function( q )
     return u;
 end );
 
+InstallGlobalFunction( AllBuekenhoutMetzAbstractUnitalParameters,
+function( q )
+    local y, filt, parampairs;
+    if not IsPrimePowerInt( q ) then
+        Error( "the argument must be a prime power" );
+    fi;
+    if IsOddInt( q ) then
+        y := X( GF(q), "y" );
+        filt := Filtered( Tuples( GF(q^2), 2 ), c -> c[1] <> Zero(GF(q^2)) );
+        parampairs := Filtered( filt,
+                                c -> RootsOfUPol( GF(q),
+                                                  y^2 - ((c[2]^q - c[2])^2 +
+                                                  4 * c[1]^(q + 1)) )
+                                     = [] );
+    fi;
+    if IsEvenInt( q ) then
+        filt := Filtered( Tuples( GF(q^2), 2 ), c -> c[1] <> Zero(GF(q^2)) and
+                                                     not ( c[2] in GF(q) ) );
+        parampairs := Filtered( filt,
+                                c -> Trace( GF(q), c[1]^(q + 1) / (c[2]^q +
+                                                   c[2])^2 )
+                                     = Zero( GF(2) ) );
+    fi;
+    return parampairs;
+end );


### PR DESCRIPTION
1. Add the function `AllBuekenhoutMetzAbstractUnitalParameters` for computing all the possible pairs of parameters for orthogonal BM-unitals. The omit the cases when the resulting unital would be the classical one.

2. Add the function `OrthogonalBuekenhoutMetzAbstractUnital`

3. Add the function `BuekenhoutTitsAbstractUnital`

4. Write down the documentation for these new functions