### PR TITLE
Fix full point method implementation

### DIFF
--- a/gap/fullpoints.gi
+++ b/gap/fullpoints.gi
@@ -39,8 +39,8 @@ InstallOtherMethod( FullPointsOfUnitalsBlocks, "for an abstract unital and two b
     [ IsAbstractUnitalDesign, IsList, IsList ],
 function( u, b1, b2 )
     local bmattr, pts, nobls, bls, ib1, ib2, nonincpts, fullpoints, p, bp, ibls, coveredpts;
-    ib1 := u!.bmat[ PositionSorted( BlocksOfUnital( u ), b1 ) ];
-    ib2 := u!.bmat[ PositionSorted( BlocksOfUnital( u ), b2 ) ];
+    ib1 := PositionSorted( BlocksOfUnital( u ), b1 );
+    ib2 := PositionSorted( BlocksOfUnital( u ), b2 );
     if b1=b2 or b1 <> BlocksOfUnital( u )[ib1] or b2 <> BlocksOfUnital( u )[ib2] then 
         Error("arguments 2 and 3 must be different blocks of the unital");
     fi;


### PR DESCRIPTION
The method `FullPointsOfUnitalsBlocks` for two blocks as lists was not working due to a mistake: instead of indices, we gave the corresponding **rows of the boolean incidence matrix** to the method `FullPointsOfUnitalsBlocks` **implemented for** pairs of **indices**.

The following (basic) piece of code won't work without the fix
```
LoadPackage("unitals");
h := HermitianAbstractUnital(4);
s := Filtered(Combinations(BlocksOfUnital(h), 2), x -> IsEmpty(Intersection(x[1], x[2])));;
bb := s[1];
FullPointsOfUnitalsBlocks(h, bb[1], bb[2]);
ss := Collected(List(s, x -> Length(FullPointsOfUnitalsBlocks(h, x[1], x[2]))));
```