### PR TITLE
Making the package (more) Windows friendly

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -80,13 +80,15 @@ PackageDoc := rec(
 ),
 
 Dependencies := rec(
-    GAP := ">= 4.8",
+    GAP := ">= 4.10.1",
     NeededOtherPackages := [
         [ "GAPDoc", ">= 1.6" ],
-        [ "Digraphs", ">= 0.11" ],
-        [ "io", ">=4.5" ]
+        [ "Digraphs", ">= 0.15.0" ],
+        [ "io", ">=4.5.4" ]
     ],
-    SuggestedOtherPackages := [ ],
+    SuggestedOtherPackages := [
+        [ "Digraphs", ">= 0.15.1" ]
+    ],
     ExternalConditions := [ ],
 ),
 

--- a/gap/libraries.gi
+++ b/gap/libraries.gi
@@ -12,7 +12,12 @@ function( nr, q, filename )
     nolines := nr * v;
     filename := Filename( DirectoriesPackageLibrary( "UnitalSZ", "data" ),
                         filename );
-    myfile := IO_FilteredFile( [ [ "gzip", [ "-dc" ] ] ], filename, "r" );
+    if filename <> fail then
+        myfile := IO_FilteredFile( [ [ "gzip", [ "-dc" ] ] ], filename, "r" );
+    else
+        filename := ReplacedString( filename, ".txt.gz", ".txt" );
+        myfile := IO_File( filename, "r" );
+    fi;
     myincmatlist := [ ];
     myincmat := [ ];
     for i in [ 1..nolines ] do

--- a/gap/libraries.gi
+++ b/gap/libraries.gi
@@ -10,12 +10,15 @@ function( nr, q, filename )
     local v, nolines, myfile, myincmatlist, myincmat, i, currentline;
     v := q^3 + 1;
     nolines := nr * v;
-    filename := Filename( DirectoriesPackageLibrary( "UnitalSZ", "data" ),
-                        filename );
-    if filename <> fail then
+    if Filename( DirectoriesPackageLibrary( "UnitalSZ", "data" ),
+                 filename ) <> fail then
+        filename := Filename( DirectoriesPackageLibrary( "UnitalSZ", "data" ),
+                              filename );
         myfile := IO_FilteredFile( [ [ "gzip", [ "-dc" ] ] ], filename, "r" );
     else
         filename := ReplacedString( filename, ".txt.gz", ".txt" );
+        filename := Filename( DirectoriesPackageLibrary( "UnitalSZ", "data" ),
+                              filename );
         myfile := IO_File( filename, "r" );
     fi;
     myincmatlist := [ ];

--- a/winrelease.sh
+++ b/winrelease.sh
@@ -1,0 +1,31 @@
+#! /bin/bash
+
+# As you can't invoke gzip using the IO package in GAP under Windows, we can't
+# ship the gzipped data of the external libraries of unitals to Windows. So
+# upon release you should run this script:
+#
+#   ./winrelease.sh
+#
+
+function usage {
+    echo -e "usage:\t\t\t`basename $0` version-number"
+    exit 1
+}
+
+# Checking the number of parameters.
+if [ $# -ne 1 ]; then
+    echo -e "`basename $0`:\t\tNot enough/too many parameters."
+    echo ""
+    usage
+fi
+
+# Creating the documentation
+gap makedoc.g
+# Unzipping the data
+gunzip data/*.gz
+# Creating the Windows release of UnitalSZ
+zip -r UnitalSZ-$1-win.zip ./* -x winrelease.sh
+# Gzipping the data
+gzip data/*.txt
+# Revert unzipping to HEAD
+git checkout HEAD data/*

--- a/winrelease.sh
+++ b/winrelease.sh
@@ -24,7 +24,13 @@ gap makedoc.g
 # Unzipping the data
 gunzip data/*.gz
 # Creating the Windows release of UnitalSZ
-zip -r UnitalSZ-$1-win.zip ./* -x winrelease.sh
+cd ..
+mkdir UnitalSZ-$1
+cp -r UnitalSZ/* UnitalSZ-$1/
+zip -r UnitalSZ-$1-win.zip UnitalSZ-$1 -x UnitalSZ-$1/winrelease.sh
+rm -rf UnitalSZ-$1
+mv UnitalSZ-$1-win.zip UnitalSZ/
+cd -
 # Gzipping the data
 gzip data/*.txt
 # Revert unzipping to HEAD


### PR DESCRIPTION
As shown in #19, the current master branch is not really usable under Windows using the latest release of GAP. This is sue to the lack of `gzip` support of GAP (more precisely the shipped Cygwin under the hood). I added a bash script to create Win-friendly release archives and modified the parsing function `AU_ReadLibraryDataFromFiles` to handle also the not `gzip`-ped `txt` files. Also updated the package dependencies, as (unfortunately) you need Digraphs 0.15.1 to get to work the package under Windows.