### PR TITLE
Fix reading in unitals stored in chunks

### DIFF
--- a/gap/libraries.gi
+++ b/gap/libraries.gi
@@ -133,7 +133,11 @@ function( name, n, chunksize )
         n0 := chunksize * Int( (n - 1) / chunksize );
         fname := LIBDATA@.(name).filename;
         fname := ReplacedString( fname, "aaa", String( n0 + 1 ) );
-        fname := ReplacedString( fname, "bbb", String( n0 + chunksize ) );
+        if ( n0 + 1 ) > ( LIBDATA@.(name).nr - chunksize ) then
+          fname := ReplacedString( fname, "bbb", String( LIBDATA@.(name).nr ) );
+        else
+          fname := ReplacedString( fname, "bbb", String( n0 + chunksize ) );
+        fi;
         r := rec( 
             nr := chunksize,
             order := LIBDATA@.(name).order,


### PR DESCRIPTION
The package wasn't able to read in the P4M unitals stored in the last chunk.

```{.gap}
gap> LoadPackage("UnitalSZ", false);
true
gap> P4MAbstractUnital(25001);
Error, no method found! For debugging hints type ?Recovery from NoMethodFound
Error, no 1st choice method found for `SplitString' on 2 arguments
The 1st argument is 'fail' which might point to an earlier problem
 at /home/mezofi/gap-4.11.0/lib/methsel2.g:249 called from
SplitString( filename, "." ) at /home/mezofi/gap-4.11.0/pkg/io-4.7.0/gap/io.gi:1474 called from
IO_CompressedFile( filename, "r" ) at /home/mezofi/.gap/pkg/UnitalSZ/gap/libraries.gi:19 called from
ReadLibraryDataFromFiles@UnitalSZ( r ) at /home/mezofi/.gap/pkg/UnitalSZ/gap/libraries.gi:142 called from
ReadAbstractUnitalFromLibraryByChunksNC@UnitalSZ( "P4M", n, 1000 ) at /home/mezofi/.gap/pkg/UnitalSZ/gap/libraries.gi:204 called from
<function "P4MAbstractUnital">( <arguments> )
 called from read-eval loop at *stdin*:2
type 'quit;' to quit to outer loop
```

The added lines fix this issue.